### PR TITLE
Modify script

### DIFF
--- a/scripts/run_models/run_lshtm_model.R
+++ b/scripts/run_models/run_lshtm_model.R
@@ -100,7 +100,7 @@ trunc_rep_mat_list <- baselinenowcast::truncate_triangles(
 )
 
 retro_rep_tri_list <- baselinenowcast::generate_triangles(
-  trunc_rep_mat_list = trunc_rep_mat_list
+  reporting_triangle_list = trunc_rep_mat_list
 )
 
 # problem here?
@@ -113,9 +113,67 @@ disp_params <- baselinenowcast::estimate_dispersion(
   pt_nowcast_mat_list = retro_pt_nowcast_mat_list,
   trunc_rep_mat_list = trunc_rep_mat_list
 )
+n_for_delay_estimate <- min(
+  sapply(retro_rep_tri_list, nrow))
+for (i in 1:length(retro_rep_tri_list)) {
+  # Get number of rows in the retrospective reporting triangle 
+  nr0 <- nrow(retro_rep_tri_list[[i]])
+  
+  # For each reporting triangle, it will use the bottom `n_for_delay_estimate`
+  # rows in the current function defaults (which are not the same as the default 
+  # configuration, and should probably be considered more carefully).
+  # Therefore, we need to check that any of these triangles contain 0s in the bottom 16 rows. 
+  if (all(retro_rep_tri_list[[i]][(nr0-n_for_delay_estimate + 1):nr0,1] == 0)) print(i)
+  
+  # We see that 1, 2, 3, and 4 all contain the bottom 16 rows as NA. 
+}
+
+# Try again with `n_for_delay_estimate=28`-------------------------------------
+# Running again being specific about how many triangles to make based on 
+# specification of 56 as the total training data. 
+
+n_for_delay_estimate <- config$hyperparams$gam$training_length/2
+n_for_uncertainty_estimate <- config$hyperparams$gam$training_length - n_for_delay_estimate
+delay_pmf <- baselinenowcast::get_delay_estimate(
+  reporting_triangle = cleaned_reporting_triangle,
+  max_delay = config$hyperparams$gam$max_delay,
+  n = n_for_delay_estimate 
+)
+
+point_nowcast_matrix <- baselinenowcast::apply_delay(
+  rep_tri_to_nowcast = cleaned_reporting_triangle,
+  delay_pmf = delay_pmf
+)
+
+trunc_rep_mat_list <- baselinenowcast::truncate_triangles(
+  reporting_triangle = cleaned_reporting_triangle,
+  n = n_for_uncertainty_estimate # This n is the number of triangles to make, not the number
+  # to use for delay estimation, though they happen to be the same 
+)
+
+retro_rep_tri_list <- baselinenowcast::generate_triangles(
+  reporting_triangle_list = trunc_rep_mat_list
+)
+# Generate 28 retrospective reporting triangles, of which the delay is estimated
+# from the last 28 rows of data. Since n
+retro_pt_nowcast_mat_list <- baselinenowcast::generate_pt_nowcast_mat_list(
+  reporting_triangle_list = retro_rep_tri_list
+)
 
 for (i in 1:length(retro_rep_tri_list)) {
-
-  if (all(retro_rep_tri_list[[i]][,1] == 0)) print(i)
-
+  # Get number of rows in the retrospective reporting triangle 
+  nr0 <- nrow(retro_rep_tri_list[[i]])
+  
+  # For each reporting triangle, it will use the bottom `n_for_delay_estimate`
+  # Therefore, we need to check that any of these triangles contain 0s in the bottom 28 rows. 
+  if (all(retro_rep_tri_list[[i]][(nr0-n_for_delay_estimate + 1):nr0,1] == 0)) print(i)
+  
 }
+# No zeros in bottom 28 rows of any of the retrospective reporting triangles,
+# therefore we can generate the retrospective point nowcasts 
+
+disp_params <- baselinenowcast::estimate_dispersion(
+  pt_nowcast_mat_list = retro_pt_nowcast_mat_list,
+  trunc_rep_mat_list = trunc_rep_mat_list
+)
+


### PR DESCRIPTION
This is certainly not ideal behaviour from our low level functions (and also think from our vignette, which doesn't explain when and how to use the `n` in these functions), but just wanted to provide an example that demonstrates why this was happening in the case that you ran. 

The TLDR is that the low level functions have defaults that aren't the same as the default configuration we refer to in the analysis plan (these will be the defaults of the wrapper function). The reason is that the default configuration relies on knowledge of information that isn't an input into the low level functions (e.g. this `generate_pt_nowcast_mat_list()` doesn't know what the `n` in `get_delay_estimate()` was). 

So by "default" as you have written, and as we have in the vignette, the `n_for_delay_estimate` is just the minimum of the number of rows of the triangles generated, which is `max_delay+2`. To check for the 0 in the delay =0 column, you had to check the bottom 16 rows. 

I rewrote at the bottom the script with the suggested configuration (half training data for delay estimation and half of it for uncertainty estimate). This just so happens to work. I discuss package solutions in the issue in `baselinenowcast`


