### PR TITLE
Modify pre and post-processing

### DIFF
--- a/scripts/run_models/functions/baselinenowcast.R
+++ b/scripts/run_models/functions/baselinenowcast.R
@@ -11,53 +11,32 @@ run_baselinenowcast <- function(.data,
 
   n_history_delay <- model_hyperparams$n_history_delay
   n_retrospective_nowcasts <- model_hyperparams$n_retrospective_nowcasts
-
-  # prepare data
-  target_data <- .data |>
-    # convert to epinowcast naming conventions
-    dplyr::rename(reference_date = specimen_date,
-                  new_confirm = target) |>
-    dplyr::mutate(report_date = reference_date + days_to_reported) |>
-    dplyr::select(-days_to_reported) |>
-    # adding this to try handle the problem calculating pobs
-    dplyr::filter(!is.na(new_confirm)) |>
-    ## apply filters to simulate real-time truncation
-    epinowcast::enw_filter_report_dates(latest_date = prediction_end_date) |>
-    epinowcast::enw_filter_reference_dates(
-      latest_date = prediction_end_date
+  eval_timeframe <- model_hyperparams$eval_timeframe
+  eval_timeframe <- 50
+  
+  # Ignoring the vignette and epinowcast preprocessing for the most part
+  training_data <- .data |>
+    rename(
+      reference_date = specimen_date
     ) |>
-    # convert to cumulative for `epinowcast` required delay structure
-    epinowcast::enw_add_cumulative()
-
-  # again, not really doing anything procesing-wise, keeping for consistent naming with vignette
-  observed_data <- epinowcast::enw_filter_report_dates(
-    target_data,
+    mutate(
+      report_date = reference_date + days_to_reported
+      ) |>
+    epinowcast::enw_filter_report_dates(
     latest_date = prediction_end_date
-  )
-
-  # enforce training length
-  training_data <- epinowcast::enw_filter_reference_dates(
-    observed_data,
-    include_days = n_training_volume - 1
-  )
-
-  latest_training_data <- epinowcast::enw_latest_data(training_data)
-
-  pobs <- epinowcast::enw_preprocess_data(
-    obs = training_data,
-    max_delay = max_delay + 1
-  )
-
-  reporting_triangle <- dplyr::select(
-    pobs$new_confirm[[1]],
-    reference_date,
-    delay,
-    new_confirm
-  ) |>
-    pivot_wider(names_from = delay, values_from = new_confirm) |>
+  ) 
+  reporting_triangle <- training_data |>
+    # Make reporting triangle by hand
+    select(reference_date, days_to_reported, target) |>
+    filter(days_to_reported <= max_delay, days_to_reported >= 0) |>
+    pivot_wider(
+      names_from = days_to_reported,
+      values_from = target
+    ) |>
     select(-reference_date) |>
     as.matrix()
 
+ 
   delay_pmf <- baselinenowcast::get_delay_estimate(
     reporting_triangle = reporting_triangle,
     max_delay = max_delay,
@@ -89,21 +68,43 @@ run_baselinenowcast <- function(.data,
   nowcast_draws_df <- baselinenowcast::get_nowcast_draws(
     point_nowcast_matrix, reporting_triangle,
     dispersion = disp_params,
-    draws = 100
+    draws = n_pi_samples
   )
 
-  latest_data_prepped <- latest_training_data |>
-    dplyr::mutate(time = row_number()) |>
-    dplyr::rename(obs_confirm = confirm) |>
-    dplyr::mutate(reference_date = as.Date(reference_date))
+  training_data_summarised<- training_data |>
+    dplyr::mutate(reference_date = as.Date(reference_date)) |>
+    group_by(reference_date) |>
+    summarise(data_as_of = sum(target, na.rm = TRUE)) 
+  # This isn't a target
+    # its the data as of the nowcast date summed across the delays that have
+    # been observed
+  
+  target_data_summarised <- .data |>
+    rename(
+      reference_date = specimen_date
+    ) |>
+    mutate(
+      report_date = reference_date + days_to_reported
+    ) |>
+    epinowcast::enw_filter_report_dates(
+      latest_date = prediction_end_date + days(eval_timeframe)
+    ) |> group_by(reference_date)|>
+    summarise(target = sum(target, na.rm = TRUE)) |># This is the actual target
+   filter(reference_date <= prediction_end_date) |>
+    arrange(reference_date,'desc') |>
+    mutate(
+      time = row_number()
+    )
+    
 
   obs_with_nowcast_draws_df <- nowcast_draws_df |>
-    dplyr::left_join(latest_data_prepped, by = "time") |>
+    dplyr::left_join(target_data_summarised, by = "time") |>
+    dplyr::mutate(reference_date = as.Date(reference_date))|>
+    dplyr::left_join(training_data_summarised, by = "reference_date") |>
     dplyr::rename(.value = pred_count,
                   specimen_date = reference_date,
-                  target = obs_confirm,
                   .sample = draw) |>
-    dplyr::select(specimen_date, .sample, target, .value) |>
+    dplyr::select(specimen_date, .sample, target, .value, data_as_of) |>
     dplyr::mutate(model = "baselinenowcast")
 
   nowcast_quantiles <- samples_to_quantiles(
@@ -111,7 +112,7 @@ run_baselinenowcast <- function(.data,
     remove_identifiers = c()) |>
     dplyr::mutate(
       dplyr::across(
-        dplyr::starts_with("pi_"), ~ .x + target
+        dplyr::starts_with("pi_"), ~ .x + target # This is meant to be observed data + nowcast, but we do that internally in the get_nowcast_draws fucntion
       )
     )|>
     dplyr::mutate(t_aggregation = "daily",

--- a/scripts/run_models/functions/baselinenowcast.R
+++ b/scripts/run_models/functions/baselinenowcast.R
@@ -112,7 +112,7 @@ run_baselinenowcast <- function(.data,
     remove_identifiers = c()) |>
     dplyr::mutate(
       dplyr::across(
-        dplyr::starts_with("pi_"), ~ .x + target # This is meant to be observed data + nowcast, but we do that internally in the get_nowcast_draws fucntion
+        dplyr::starts_with("pi_"), ~ .x # This is meant to be observed data + nowcast, but we do that internally in the get_nowcast_draws fucntion
       )
     )|>
     dplyr::mutate(t_aggregation = "daily",

--- a/scripts/run_models/functions/baselinenowcast.R
+++ b/scripts/run_models/functions/baselinenowcast.R
@@ -12,7 +12,6 @@ run_baselinenowcast <- function(.data,
   n_history_delay <- model_hyperparams$n_history_delay
   n_retrospective_nowcasts <- model_hyperparams$n_retrospective_nowcasts
   eval_timeframe <- model_hyperparams$eval_timeframe
-  eval_timeframe <- 50
   
   # Ignoring the vignette and epinowcast preprocessing for the most part
   training_data <- .data |>
@@ -110,11 +109,13 @@ run_baselinenowcast <- function(.data,
   nowcast_quantiles <- samples_to_quantiles(
     .sample_predictions = obs_with_nowcast_draws_df,
     remove_identifiers = c()) |>
-    dplyr::mutate(
-      dplyr::across(
-        dplyr::starts_with("pi_"), ~ .x # This is meant to be observed data + nowcast, but we do that internally in the get_nowcast_draws fucntion
-      )
-    )|>
+    # Remove this step because observations + predicted nowcast draws already
+    # happened in `get_nowcast_draws()`
+    # dplyr::mutate(
+    #   dplyr::across(
+    #     dplyr::starts_with("pi_"), ~ .x + target
+    #   )
+    # )|>
     dplyr::mutate(t_aggregation = "daily",
                   prediction_end_date = prediction_end_date,
                   model = "baselinenowcast")

--- a/scripts/run_models/norovirus_nowcast_config.yaml
+++ b/scripts/run_models/norovirus_nowcast_config.yaml
@@ -26,6 +26,7 @@ hyperparams:
     max_delay: 14
     n_history_delay: 28
     n_retrospective_nowcasts: 28
+    eval_timeframe: 50
 
 
   bsts:


### PR DESCRIPTION
This PR modifies the pre and post-processing in `baselinenowcast.R`. 

It makes the following major modifications:
- it removes the part of the generation of the nowcast quantiles where the `target` (observed data as of the nowcast date) is added to the probabilistic draw. The combining of the observations and the predicted component of the nowcast draws already takes place within the `get_nowcast_draws()` function (see here https://github.com/epinowcast/baselinenowcast/blob/abcb510ff813f64157a2eb9e8d527c023d175280/vignettes/baselinenowcast.Rmd#L463). Noting that this was a change in the past month to the user workflow which is likely to explain this confusion
- it defines the `target` in the output as the final evaluation data, using the new config parameter `eval_timeframe`. I actually am not sure if this is supposed to be in this part of the workflow, or if you plan to later compare the predicted nowcasts to the data available 50 days after the nowcast. The output of `baselinenowcast()` now generates two columns: `target` = target evaluation data (final counts at each specimen data from 50 days after the nowcast date) and `data_as_of` which is the total counts at each reference date as of the nowcast date (this one will be right-truncated). 

You may wish to ignore the change in the second component, and only make the change:
https://github.com/jonathonmellor/norovirus-nowcast/blob/7453bca359b6f1c67223ee7d99bf7ed8e7be93b4/scripts/run_models/functions/baselinenowcast.R#L114

to `dplyr::starts_with("pi_"), ~ .x `

Apologies for not catching this combining of the observed and nowcasted data sooner! I was mainly focusing on my review of how the `baselinenowcast` pipeline was being used which was correct. 

Resulting nowcasts, plotted against the evaluation data 50 days from each nowcast date:
![image](https://github.com/user-attachments/assets/e4f3610d-eb82-4c04-b156-7fb59ffc3c06)

These are much more consistent with the ones we had previously generated. 